### PR TITLE
openhab compatibility

### DIFF
--- a/firmware/firmware.ino
+++ b/firmware/firmware.ino
@@ -2,13 +2,13 @@
 #include "Adafruit_MQTT.h"
 #include "Adafruit_MQTT_Client.h"
 
-#define WLAN_SSID   "YOUR SSID"
-#define WLAN_PASS   "YOUR PASSWORD"
+#define WLAN_SSID   "WLAN SSID"
+#define WLAN_PASS   "WLAN PSK"
 
-#define SERVER      "minibian" // The hostname of the server where the MQTT broker is installed
+#define SERVER      "host" // The hostname of the server where the MQTT broker is installed
 #define SERVERPORT  1883 // The port of the MQTT broker
 
-#define LED         4   // Pin controlling to the LED strip.
+#define LED         0   // Pin controlling to the LED strip.
 
 
 unsigned int i = 0;
@@ -19,8 +19,8 @@ bool led_on = false;
 WiFiClient client;
 
 Adafruit_MQTT_Client mqtt(&client, SERVER, SERVERPORT);
-Adafruit_MQTT_Subscribe onoffsw = Adafruit_MQTT_Subscribe(&mqtt, "/light/1");
-Adafruit_MQTT_Publish status_mqtt = Adafruit_MQTT_Publish(&mqtt, "/light/1/status");
+Adafruit_MQTT_Subscribe onoffsw = Adafruit_MQTT_Subscribe(&mqtt, "home/out/AquariumLight1/command");
+Adafruit_MQTT_Publish status_mqtt = Adafruit_MQTT_Publish(&mqtt, "home/in/AquariumLight1/state");
 
 void setup() {
   // Initialization
@@ -32,8 +32,8 @@ void setup() {
 
   // We start by connecting to a WiFi network
   Serial.print("Connecting to ");
-  Serial.println(ssid);
-  WiFi.begin(ssid, pass);
+  Serial.println(WLAN_SSID);
+  WiFi.begin(WLAN_SSID, WLAN_PASS);
   
   while (WiFi.status() != WL_CONNECTED) {
     delay(500);

--- a/openhab/state-to-json.rules
+++ b/openhab/state-to-json.rules
@@ -1,0 +1,23 @@
+//put this file in your /etc/openhab2/rules folder
+rule "State to JSON"
+	when
+		Item AquariumLight1Dimmer received command
+	then
+		val SwitchNum = if (AquariumLight1Dimmer.state == 0) 0 else 1
+		var jsonString = "{\"On\":" + SwitchNum
+		jsonString = jsonString + "}"
+
+		AquariumLight1.sendCommand(jsonString)
+
+end
+
+rule "Brightness to JSON"
+	when
+		Item AquariumLight1Dimmer received command
+	then
+		var jsonString = "{\"Brightness\":" + AquariumLight1Dimmer.state.toString
+		jsonString = jsonString + "}"
+
+		AquariumLight1.sendCommand(jsonString)
+
+end


### PR DESCRIPTION
- A few modifications to make it work with an ESP8266, , they only have 2 I/O pins. I used pin 0 in a previous hardware version.
- .rules file for easy use with openHAB.

future improvements might include:
- dynamic ESP hostname(topic) & openhab proxy rule config
- make it interpret a whole JSON object correctly (what JSON is meant for). It currently won't work if you send it an array of parameters.